### PR TITLE
We use repoze.retry in our zope2 wsgi pipeline, and want ConflictErrors show up in the log only when they couldn't be resolved.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,6 +7,8 @@ After 1.0
 
 - Fix handling of case where environ['CONTENT_LENGTH'] is an empty string.
 
+- Added possibility of tracebacks being written to wsgi.errors only after
+  the specified number of tries.
 
 1.0 (2010-08-09)
 ----------------

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,1 @@
+include *.txt

--- a/repoze/retry/__init__.py
+++ b/repoze/retry/__init__.py
@@ -20,7 +20,8 @@ except ImportError:
         pass
 
 class Retry:
-    def __init__(self, application, tries, retryable=None, highwater=2<<20):
+    def __init__(self, application, tries, retryable=None, highwater=2<<20,
+            tries_write_error=1):
         """ WSGI Middlware which retries a configurable set of exception types.
 
         o 'application' is the RHS in the WSGI "pipeline".
@@ -30,7 +31,8 @@ class Retry:
         o 'retryable' is a sequence of one or more exception types which,
           if raised, indicate that the request should be retried.
 
-        o
+        o 'tries_write_error' specified after how many tries the error is
+          written to wsgi.errors
         """
         self.application = application
         self.tries = tries
@@ -43,6 +45,7 @@ class Retry:
 
         self.retryable = tuple(retryable)
         self.highwater = highwater
+        self.tries_write_error = tries_write_error
 
     def __call__(self, environ, start_response):
         catch_response = []
@@ -94,7 +97,7 @@ class Retry:
             except self.retryable, e:
                 i += 1
                 errors = environ.get('wsgi.errors')
-                if errors is not None:
+                if errors is not None and i >= self.tries_write_error:
                     errors.write('repoze.retry retrying, count = %s\n' % i)
                     traceback.print_exc(None, errors)
                 if i < self.tries:
@@ -126,7 +129,9 @@ def make_retry(app, global_conf, **local_conf):
     tries = int(local_conf.get('tries', 3))
     retryable = local_conf.get('retryable')
     highwater = local_conf.get('highwater', 2<<20)
+    tries_write_error = int(local_conf.get('tries_write_error', 1))
     if retryable is not None:
         retryable = [EntryPoint.parse('x=%s' % x).load(False)
                       for x in retryable.split(' ')]
-    return Retry(app, tries, retryable=retryable, highwater=highwater)
+    return Retry(app, tries, retryable=retryable, highwater=highwater,
+        tries_write_error=tries_write_error)


### PR DESCRIPTION
Added possibility of tracebacks being written to wsgi.errors only after the specified number of tries.
It would be nice if you can integrate this and make a release, because the other change (environ['CONTENT_LENGTH'] is an empty string) does also bug us. ;)

Greetings
