### PR TITLE
Retry 'transaction.intefaces.TransientError' by default.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,8 @@ matrix:
     - python: pypy3
       env: TOXENV=pypy3
     - python: 3.8
+      env: TOXENV=w_deps
+    - python: 3.8
       env: TOXENV=cover
 
 install:

--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,8 @@
 
 - Sleep for delay on retrying using the delay parameter.
 
+- Retry ``transaction.interfaces.TransientError`` (if importable) by default.
+
 1.4 (2016-06-03)
 ----------------
 

--- a/repoze/retry/__init__.py
+++ b/repoze/retry/__init__.py
@@ -6,6 +6,13 @@ import traceback
 from io import BytesIO
 from time import sleep
 
+# Avoid hard dependency on transaction.
+try:
+    from transaction.interfaces import TransientError
+except ImportError:
+    class TransientError(Exception):
+        pass
+
 # Avoid hard dependency on ZODB.
 try:
     from ZODB.POSException import ConflictError
@@ -43,7 +50,7 @@ class Retry:
         self.tries = tries
 
         if retryable is None:
-            retryable = (ConflictError, RetryException,)
+            retryable = (TransientError, ConflictError, RetryException,)
 
         if not isinstance(retryable, (list, tuple)):
             retryable = [retryable]

--- a/repoze/retry/tests.py
+++ b/repoze/retry/tests.py
@@ -24,6 +24,12 @@ else:
 
 class CEBase:
 
+    def _getTransientError(self):
+        from repoze.retry import TransientError
+        return TransientError
+
+    TransientError = property(_getTransientError,)
+
     def _getConflictError(self):
         from repoze.retry import ConflictError
         return ConflictError
@@ -413,12 +419,11 @@ class FactoryTests(unittest.TestCase, CEBase):
         self.assertEqual(middleware.tries, 3)
         self.assertEqual(middleware.tries, 3)
         self.assertEqual(middleware.log_after_try_count, 1)
-        expected = [self.ConflictError, self.RetryException]
-
-        if _HAVE_TRANSACTION:
-            from transaction.interfaces import TransientError
-            expected.insert(0, TransientError)
-
+        expected = [
+            self.TransientError,
+            self.ConflictError,
+            self.RetryException,
+        ]
         self.assertEqual(middleware.retryable, tuple(expected))
 
     def test_make_retry_override_tries(self):
@@ -427,12 +432,11 @@ class FactoryTests(unittest.TestCase, CEBase):
         middleware = make_retry(app, {}, tries=4)
         self.assertTrue(middleware.application is app)
         self.assertEqual(middleware.tries, 4)
-        expected = [self.ConflictError, self.RetryException]
-
-        if _HAVE_TRANSACTION:
-            from transaction.interfaces import TransientError
-            expected.insert(0, TransientError)
-
+        expected = [
+            self.TransientError,
+            self.ConflictError,
+            self.RetryException,
+        ]
         self.assertEqual(middleware.retryable, tuple(expected))
 
     def test_make_retry_override_tries_write_error(self):

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,18 @@
 [tox]
 envlist = 
-    py27,pypy,py35,py36,py37,py38,pypy3,cover,docs
+    py27,pypy,py35,py36,py37,py38,pypy3,w_deps,cover,docs
 
 [testenv]
+commands = 
+    python setup.py -q test -q
+
+[testenv:w_deps]
+basepython =
+    python3.8
+deps =
+    transaction
+    ZODB
+    Zope
 commands = 
     python setup.py -q test -q
 


### PR DESCRIPTION
If not importable, skip.

Add tests for retries of exceptions from optional dependencies, including `transaction` / `ZODB` / `Zope`.

Closes #4.